### PR TITLE
Fix and update libnetfilter_queue bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,13 @@ name = "nfqueue"
 version = "0.9.1"
 authors = [ "Pierre Chifflier <chifflier@wzdftpd.net>" ]
 
+build = "src/generation/generate_bindings.rs"
+
+[build-dependencies]
+bindgen = "^0.26"
+
 [dependencies]
 libc = "^0.2"
 
-[dev_dependencies]
+[dev-dependencies]
 pnet = "0.17.1"

--- a/examples/nfq-example.rs
+++ b/examples/nfq-example.rs
@@ -11,7 +11,7 @@ impl State {
     }
 }
 
-fn queue_callback(msg: &nfqueue::Message, state:&mut State) {
+fn queue_callback(msg: nfqueue::Message, state:&mut State) -> i32 {
     println!("Packet received [id: 0x{:x}]\n", msg.get_id());
 
     println!(" -> msg: {}", msg);
@@ -21,18 +21,19 @@ fn queue_callback(msg: &nfqueue::Message, state:&mut State) {
     state.count += 1;
     println!("count: {}", state.count);
 
-    msg.set_verdict(nfqueue::Verdict::Accept);
+    msg.set_verdict(nfqueue::Verdict::Accept)
 }
 
 fn main() {
     let mut q = nfqueue::Queue::new(State::new());
     println!("nfqueue example program: print packets metadata and accept packets");
 
+    let protocol_family = libc::AF_INET as u16;
+
     q.open();
-    q.unbind(libc::AF_INET); // ignore result, failure is not critical here
+    q.unbind(protocol_family); // ignore result, failure is not critical here
 
-
-    let rc = q.bind(libc::AF_INET);
+    let rc = q.bind(protocol_family);
     assert!(rc == 0);
 
     q.create_queue(0, queue_callback);

--- a/examples/nfq-example.rs
+++ b/examples/nfq-example.rs
@@ -1,5 +1,5 @@
-extern crate nfqueue;
 extern crate libc;
+extern crate nfqueue;
 
 struct State {
     count: u32,
@@ -39,10 +39,6 @@ fn main() {
     q.create_queue(0, queue_callback);
     q.set_mode(nfqueue::CopyMode::CopyPacket, 0xffff);
 
-
     q.run_loop();
-
-
-
     q.close();
 }

--- a/examples/nfq-parse.rs
+++ b/examples/nfq-parse.rs
@@ -1,7 +1,7 @@
 // Some code borrowed from https://github.com/libpnet/libpnet/blob/master/examples/packetdump.rs
 
-extern crate nfqueue;
 extern crate libc;
+extern crate nfqueue;
 
 use std::net::IpAddr;
 
@@ -165,17 +165,12 @@ fn main() {
     q.open();
     q.unbind(protocol_family); // ignore result, failure is not critical here
 
-
     let rc = q.bind(protocol_family);
     assert!(rc == 0);
 
     q.create_queue(0, queue_callback);
     q.set_mode(nfqueue::CopyMode::CopyPacket, 0xffff);
 
-
     q.run_loop();
-
-
-
     q.close();
 }

--- a/examples/nfq-parse.rs
+++ b/examples/nfq-parse.rs
@@ -134,7 +134,7 @@ fn handle_transport_protocol(id: u32, source: IpAddr, destination: IpAddr, proto
     }
 }
 
-fn queue_callback(msg: &nfqueue::Message, state: &mut State) {
+fn queue_callback(msg: nfqueue::Message, state: &mut State) -> i32 {
     println!("\n---");
     println!("Packet received [id: 0x{:x}]\n", msg.get_id());
 
@@ -153,18 +153,20 @@ fn queue_callback(msg: &nfqueue::Message, state: &mut State) {
         None    => println!("Malformed IPv4 packet"),
     }
 
-    msg.set_verdict(nfqueue::Verdict::Accept);
+    msg.set_verdict(nfqueue::Verdict::Accept)
 }
 
 fn main() {
     let mut q = nfqueue::Queue::new(State::new());
     println!("nfqueue example program: parse packet protocol layers and accept packet");
 
+    let protocol_family = libc::AF_INET as u16;
+
     q.open();
-    q.unbind(libc::AF_INET); // ignore result, failure is not critical here
+    q.unbind(protocol_family); // ignore result, failure is not critical here
 
 
-    let rc = q.bind(libc::AF_INET);
+    let rc = q.bind(protocol_family);
     assert!(rc == 0);
 
     q.create_queue(0, queue_callback);

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,1 +1,5 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/generation/generate_bindings.rs
+++ b/src/generation/generate_bindings.rs
@@ -16,6 +16,7 @@ fn main() {
         .whitelisted_type("(nfq|NFQ)_.*")
         .whitelisted_function("(nfq|NFQ)_.*")
         .whitelisted_var("(nfq|NFQ)_.*")
+        .constified_enum(".*")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/generation/generate_bindings.rs
+++ b/src/generation/generate_bindings.rs
@@ -1,0 +1,26 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+
+    // Tell cargo to tell rustc to link the netfilter_queue shared library
+    println!("cargo:rustc-link-lib=netfilter_queue");
+
+    let bindings = bindgen::Builder::default()
+        .header("src/generation/wrapper.h")
+        // White listings became necessary as I needed to included <stdint> in wrapper.h to
+        // define the default integer types like uint32_t. I think I miss something but I
+        // couldn't grab it.
+        .whitelisted_type("(nfq|NFQ)_.*")
+        .whitelisted_function("(nfq|NFQ)_.*")
+        .whitelisted_var("(nfq|NFQ)_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/src/generation/wrapper.h
+++ b/src/generation/wrapper.h
@@ -1,0 +1,2 @@
+#include <stdint.h>
+#include <libnetfilter_queue/libnetfilter_queue.h>

--- a/src/message.rs
+++ b/src/message.rs
@@ -4,8 +4,6 @@ use bindings::*;
 use hwaddr::*;
 use std;
 
-type NfqueueData = *const libc::c_void;
-
 /// Opaque struct `Message`: abstracts NFLOG data representing a packet data and metadata
 pub struct Message {
     qqh  : *mut nfq_q_handle,
@@ -72,17 +70,6 @@ const NFQ_XML_PHYSDEV : i32  = (1 << 3);
 const NFQ_XML_PAYLOAD : i32  = (1 << 4);
 const NFQ_XML_TIME    : i32  = (1 << 5);
 const NFQ_XML_ALL     : i32  = (!0u32) as i32;
-
-/// Hardware address
-#[repr(C)]
-struct NfMsgPacketHw {
-    /// Hardware address length
-    pub hw_addrlen : u16,
-    /// Padding (should be ignored)
-    pub _pad : u16,
-    /// The hardware address
-    pub hw_addr : [u8;8],
-}
 
 /// Metaheader wrapping a packet
 #[repr(C)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -63,14 +63,6 @@ pub enum XMLFormatFlags {
     XmlAll,
 }
 
-const NFQ_XML_HW      : i32  = (1 << 0);
-const NFQ_XML_MARK    : i32  = (1 << 1);
-const NFQ_XML_DEV     : i32  = (1 << 2);
-const NFQ_XML_PHYSDEV : i32  = (1 << 3);
-const NFQ_XML_PAYLOAD : i32  = (1 << 4);
-const NFQ_XML_TIME    : i32  = (1 << 5);
-const NFQ_XML_ALL     : i32  = (!0u32) as i32;
-
 /// Metaheader wrapping a packet
 #[repr(C)]
 pub struct NfMsgPacketHdr {
@@ -287,9 +279,9 @@ impl Message {
                 XMLFormatFlags::XmlTime    => NFQ_XML_TIME,
                 XMLFormatFlags::XmlAll     => NFQ_XML_ALL,
             }
-        }).fold(0i32, |acc, i| acc | i);
+        }).fold(0u32, |acc, i| acc | i);
 
-        let rc = unsafe { nfq_snprintf_xml(buf_ptr, buf_len, self.nfad, xml_flags) };
+        let rc = unsafe { nfq_snprintf_xml(buf_ptr, buf_len, self.nfad, xml_flags as i32) };
         if rc < 0 { panic!("nfq_snprintf_xml"); } // XXX see snprintf error codes
 
         match std::str::from_utf8(&buf) {


### PR DESCRIPTION
Uses servo/bindgen to generate improved bindings for libnetfilter_queue and integrates them in the given wrapper methods.